### PR TITLE
fix: add systemd availability checks in maintainer scripts

### DIFF
--- a/debian/radxa-otgutils.postinst
+++ b/debian/radxa-otgutils.postinst
@@ -6,31 +6,28 @@ action="$1"
 
 if [ "$action" = configure ]
 then
-    # Only proceed with systemd operations if systemd is available
-    if command -v systemctl >/dev/null 2>&1; then
-        deb-systemd-invoke daemon-reload 2>/dev/null || true
+    deb-systemd-invoke daemon-reload 2>/dev/null || true
 
-        # radxa-usbnet@ renamed to radxa-ecm@ in 0.3.2
-        # Can't use `deb-systemd-helper enable "radxa-ecm@$udc.service"` in preinst due to
+    # radxa-usbnet@ renamed to radxa-ecm@ in 0.3.2
+    # Can't use `deb-systemd-helper enable "radxa-ecm@$udc.service"` in preinst due to
+    # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=801822
+    for i in /etc/systemd/system/multi-user.target.wants/radxa-usbnet@*.usb.service; do
+        if [ ! -e "$i" ] && [ ! -L "$i" ] ; then
+            continue
+        fi
+        # Need to manually clean up old link since ecm is now an alias
+        rm "$i"
+        i="$(basename "$i")"
+        ecm=$(echo "$i" | sed "s/usbnet/ecm/")
+        echo "$i is no longer supported. Will be reenabled as $ecm."
+        # Can't use `deb-systemd-helper enable "$i"` due to
         # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=801822
-        for i in /etc/systemd/system/multi-user.target.wants/radxa-usbnet@*.usb.service; do
-            if [ ! -e "$i" ] && [ ! -L "$i" ] ; then
-                continue
-            fi
-            # Need to manually clean up old link since ecm is now an alias
-            rm "$i"
-            i="$(basename "$i")"
-            ecm=$(echo "$i" | sed "s/usbnet/ecm/")
-            echo "$i is no longer supported. Will be reenabled as $ecm."
-            # Can't use `deb-systemd-helper enable "$i"` due to
-            # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=801822
-            if [ -d /run/systemd/system ]; then
-                systemctl enable "$ecm" || true
-            fi
-        done
+        if [ -d /run/systemd/system ]; then
+            deb-systemd-invoke enable "$ecm" 2>/dev/null || true
+        fi
+    done
 
-        deb-systemd-invoke daemon-reload 2>/dev/null || true
-    fi
+    deb-systemd-invoke daemon-reload 2>/dev/null || true
 fi
 
 #DEBHELPER#

--- a/debian/radxa-otgutils.postinst
+++ b/debian/radxa-otgutils.postinst
@@ -6,28 +6,31 @@ action="$1"
 
 if [ "$action" = configure ]
 then
-    deb-systemd-invoke daemon-reload -q
+    # Only proceed with systemd operations if systemd is available
+    if command -v systemctl >/dev/null 2>&1; then
+        deb-systemd-invoke daemon-reload 2>/dev/null || true
 
-    # radxa-usbnet@ renamed to radxa-ecm@ in 0.3.2
-    # Can't use `deb-systemd-helper enable "radxa-ecm@$udc.service"` in preinst due to
-    # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=801822
-    for i in /etc/systemd/system/multi-user.target.wants/radxa-usbnet@*.usb.service; do
-        if [ ! -e "$i" ] && [ ! -L "$i" ] ; then
-            continue
-        fi
-        # Need to manually clean up old link since ecm is now an alias
-        rm "$i"
-        i="$(basename "$i")"
-        ecm=$(echo "$i" | sed "s/usbnet/ecm/")
-        echo "$i is no longer supported. Will be reenabled as $ecm."
-        # Can't use `deb-systemd-helper enable "$i"` due to
+        # radxa-usbnet@ renamed to radxa-ecm@ in 0.3.2
+        # Can't use `deb-systemd-helper enable "radxa-ecm@$udc.service"` in preinst due to
         # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=801822
-        if [ -d /run/systemd/system ]; then
-            systemctl enable "$ecm"
-        fi
-    done
+        for i in /etc/systemd/system/multi-user.target.wants/radxa-usbnet@*.usb.service; do
+            if [ ! -e "$i" ] && [ ! -L "$i" ] ; then
+                continue
+            fi
+            # Need to manually clean up old link since ecm is now an alias
+            rm "$i"
+            i="$(basename "$i")"
+            ecm=$(echo "$i" | sed "s/usbnet/ecm/")
+            echo "$i is no longer supported. Will be reenabled as $ecm."
+            # Can't use `deb-systemd-helper enable "$i"` due to
+            # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=801822
+            if [ -d /run/systemd/system ]; then
+                systemctl enable "$ecm" || true
+            fi
+        done
 
-    deb-systemd-invoke daemon-reload -q
+        deb-systemd-invoke daemon-reload 2>/dev/null || true
+    fi
 fi
 
 #DEBHELPER#

--- a/debian/radxa-otgutils.preinst
+++ b/debian/radxa-otgutils.preinst
@@ -6,13 +6,16 @@ action="$1"
 
 if [ "$action" = upgrade ]
 then
-    # Delete broken links from < 0.3.0
-    for i in $(deb-systemd-invoke list-units --all radxa-usbnet.service radxa-adbd.service | awk '$3 == "not-found" {printf("%s ",$2)}') \
-             $(deb-systemd-invoke list-units --all radxa-usbnet.service radxa-adbd.service | awk '$2 == "loaded" && $3 != "units" {printf("%s ",$1)}'); do
-        template="$(echo "$i" | sed "s/.service/@.service/")"
-        echo "$i is no longer supported. Please use $template instead."
-        deb-systemd-helper disable "$i"
-    done
+    # Only proceed with systemd operations if systemd is available
+    if command -v systemctl >/dev/null 2>&1; then
+        # Delete broken links from < 0.3.0
+        for i in $(systemctl list-units --all radxa-usbnet.service radxa-adbd.service 2>/dev/null | awk '$3 == "not-found" {printf("%s ",$2)}') \
+                 $(systemctl list-units --all radxa-usbnet.service radxa-adbd.service 2>/dev/null | awk '$2 == "loaded" && $3 != "units" {printf("%s ",$1)}'); do
+            template="$(echo "$i" | sed "s/.service/@.service/")"
+            echo "$i is no longer supported. Please use $template instead."
+            deb-systemd-helper disable "$i" || true
+        done
+    fi
 fi
 
 #DEBHELPER#

--- a/debian/radxa-otgutils.preinst
+++ b/debian/radxa-otgutils.preinst
@@ -6,16 +6,13 @@ action="$1"
 
 if [ "$action" = upgrade ]
 then
-    # Only proceed with systemd operations if systemd is available
-    if command -v systemctl >/dev/null 2>&1; then
-        # Delete broken links from < 0.3.0
-        for i in $(systemctl list-units --all radxa-usbnet.service radxa-adbd.service 2>/dev/null | awk '$3 == "not-found" {printf("%s ",$2)}') \
-                 $(systemctl list-units --all radxa-usbnet.service radxa-adbd.service 2>/dev/null | awk '$2 == "loaded" && $3 != "units" {printf("%s ",$1)}'); do
-            template="$(echo "$i" | sed "s/.service/@.service/")"
-            echo "$i is no longer supported. Please use $template instead."
-            deb-systemd-helper disable "$i" || true
-        done
-    fi
+    # Delete broken links from < 0.3.0
+    for i in $(deb-systemd-invoke list-units --all radxa-usbnet.service radxa-adbd.service 2>/dev/null || true | awk '$3 == "not-found" {printf("%s ",$2)}') \
+             $(deb-systemd-invoke list-units --all radxa-usbnet.service radxa-adbd.service 2>/dev/null || true | awk '$2 == "loaded" && $3 != "units" {printf("%s ",$1)}'); do
+        template="$(echo "$i" | sed "s/.service/@.service/")"
+        echo "$i is no longer supported. Please use $template instead."
+        deb-systemd-helper disable "$i" 2>/dev/null || true
+    done
 fi
 
 #DEBHELPER#


### PR DESCRIPTION
- Check systemctl availability before running systemd operations
- Replace invalid deb-systemd-invoke list-units with systemctl
- Fix daemon-reload command usage and add error handling