### PR TITLE
feat: update adbd dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,7 @@ Architecture: all
 Section: admin
 Priority: standard
 Depends: ${misc:Depends},
-Recommends: adbd | rockchip-adbd-provider | android-tools-adbd,
+         adbd | rockchip-adbd-provider | android-tools-adbd,
 Description: Radxa USB OTG utility
  Radxa USB OTG utility (radxa-otgutils) provides additional
  features over USB OTG port to facilitate easy communication

--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,7 @@ Architecture: all
 Section: admin
 Priority: standard
 Depends: ${misc:Depends},
-Recommends: rockchip-adbd-provider | android-tools-adbd,
+Recommends: adbd | rockchip-adbd-provider | android-tools-adbd,
 Description: Radxa USB OTG utility
  Radxa USB OTG utility (radxa-otgutils) provides additional
  features over USB OTG port to facilitate easy communication


### PR DESCRIPTION
    feat: update adbd dependency
    
    On O6N running this image[0], connecting the Type-C port to a host
    machine and enabing the adb service using rsetup[1]; when a USB2.0 cable
    is used, the host machine can detect the O6N as an adb device, but it's
    not the case with a USB3.0 cable. When a USB3.0 cable is used, the
    GNU/Linux host machine kernel message shows:
    ```
    usb 2-8.4: no configurations
    usb 2-8.4: can't read configurations, error -22
    usb 2-8.4: new SuperSpeed USB device number 16 using xhci_hcd
    usb 2-8.4: no configurations
    usb 2-8.4: can't read configurations, error -22
    usb 2-8-port4: attempt power cycle
    usb 2-8.4: new SuperSpeed USB device number 17 using xhci_hcd
    usb 2-8.4: no configurations
    usb 2-8.4: can't read configurations, error -22
    ```
    The issue can be solved by updating adbd to the one presents in Debian
    bookworm-backports[2].
    
    [0]: https://github.com/radxa-build/radxa-orion-cix-p1/releases/download/rsdk-t4/radxa-orion-cix-p1_bookworm_gnome_t4.output_512.img.xz
    [1]: https://docs.radxa.com/template/sbc/os-config/rsetup#usb-otg-services
    [2]: https://packages.debian.org/bookworm-backports/adbd