### PR TITLE
fix: use which command to find adbd path

### DIFF
--- a/src/radxa-otgutils
+++ b/src/radxa-otgutils
@@ -160,7 +160,7 @@ start()
                 mount -o uid=2000,gid=2000 -t functionfs adb /dev/usb-ffs/adb
             fi
             export service_adb_tcp_port=5555
-            start-stop-daemon --start --oknodo --make-pidfile --pidfile /var/run/adbd.pid --startas /usr/bin/adbd --background
+            start-stop-daemon --start --oknodo --make-pidfile --pidfile /var/run/adbd.pid --startas "$(which adbd)" --background
             sleep 0.1
             ;;
     esac


### PR DESCRIPTION
    fix: use which command to find adbd path
    
    The OS may use the adbd[0] or the android-tools-adbd[1] packages. The
    adbd package installs adbd to /usr/sbin/adbd[2] while android-tools-adbd
    to /usr/bin/adbd. Use `which` command to find the adbd path so
    radxa-otgutils is compatible with both of the packages.
    
    [0]: https://github.com/radxa-pkg/radxa-otgutils/blob/f91fa37fd6387e6980f44780f940b18bbdfd28fe/debian/control#L18
    [1]: https://github.com/radxa-pkg/android-tools-adbd/releases/download/5.1.1.r38-1.1/android-tools-adbd_5.1.1.r38-1.1_arm64.deb
    [2]: https://salsa.debian.org/android-tools-team/android-platform-tools/-/blob/4294a676c873a3912702f7e2081510edbdc609cb/debian/adbd.links