### PR TITLE
fix: disable adbd in systemd preset

### DIFF
--- a/debian/install
+++ b/debian/install
@@ -1,3 +1,4 @@
 src/radxa-otgutils /usr/sbin/
+src/presets/90-adbd.preset /usr/lib/systemd/system-preset/
 services.json /usr/share/radxa-otgutils/
 man/*.8 /usr/share/man/man8

--- a/debian/radxa-otgutils.radxa-adbd@.service
+++ b/debian/radxa-otgutils.radxa-adbd@.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=Enable adbd on %i
 Documentation=https://github.com/radxa-pkg/radxa-otgutils/
+Conflicts=adbd.service
+Before=adbd.service
 
 [Service]
 Type=oneshot

--- a/src/presets/90-adbd.preset
+++ b/src/presets/90-adbd.preset
@@ -1,0 +1,1 @@
+disable adbd.service


### PR DESCRIPTION
    fix: disable adbd in systemd preset
    
    The service adbd calls[0] the script which conflicts[1] with the
    radxa-otgutils script[2]. For radxa-otgutils to work, disable
    adbd.service in systemd preset so adbd.service will not be started and
    enabled at the first boot[3].
    
    [0]: https://salsa.debian.org/android-tools-team/android-platform-tools/-/blob/20425ddcead2dbc98dcee9031ae88de516fe3059/debian/adbd.service#L9
    [1]: https://salsa.debian.org/android-tools-team/android-platform-tools/-/blob/20425ddcead2dbc98dcee9031ae88de516fe3059/debian/bin/adbd-usb-gadget#L23-52
    [2]: https://github.com/radxa-pkg/radxa-otgutils/blob/f91fa37fd6387e6980f44780f940b18bbdfd28fe/src/radxa-otgutils#L155-L164
    [3]: 'enabling or disabling them according to the systemd.preset(5) settings' man systemd-firstboot